### PR TITLE
RA-1209 - Change to 'Get referral system subscribers'

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -146,6 +146,9 @@ Update referral system for specific organization
         
 ### Get referral system subscribers [/organizations/1/referral-system/subscribers] [GET]        
 
++ `created_at`: date of registration
++ `subscriber_date`: date of subscription
+
 + Response 200 (application/json)
         {
            "potential": [
@@ -156,7 +159,9 @@ Update referral system for specific organization
                    "subscriber_date": null,
                    "status_id": "1",
                    "created_at": null,
-                   "updated_at": null
+                   "updated_at": null,
+                   "is_new": true,
+                   "user_name: "John Doe"
                },
                {
                    "id": 3,
@@ -165,7 +170,9 @@ Update referral system for specific organization
                    "subscriber_date": null,
                    "status_id": "1",
                    "created_at": 2017-08-24 00:00:00,
-                   "updated_at": null
+                   "updated_at": null,
+                   "is_new": false,
+                   "user_name: "Test User1"
                }
            ],
            "confirmed": [
@@ -176,7 +183,9 @@ Update referral system for specific organization
                    "subscriber_date": 2017-08-24 00:00:00,
                    "status_id": "2",
                    "created_at": 2017-07-24 00:00:00,
-                   "updated_at": null
+                   "updated_at": null,
+                   "is_new": false,
+                   "user_name: "Test User2"
                }
            ]
         }


### PR DESCRIPTION
As was mentioned in https://github.com/DimaUlyanets/graspe-api-docs/pull/7 . 

`is_new`: `boolean`. It should let me know if user already seen this referral. So, if specific referral was added(or referral which changed it's state from 'potential' to 'confirmed') after last user's request to `GET` `/organizations/1/referral-system/subscribers` then this referral should have `is_new`: `true`